### PR TITLE
LLVM Corrections

### DIFF
--- a/include/json5/json5.hpp
+++ b/include/json5/json5.hpp
@@ -199,6 +199,7 @@ public:
 	{
 	public:
 		iterator( const value *p = nullptr ) noexcept : _pair( p ) { }
+		bool operator!=( const iterator &other ) const noexcept { return _pair != other._pair; }
 		bool operator==( const iterator &other ) const noexcept { return _pair == other._pair; }
 		iterator &operator++() noexcept { _pair += 2; return *this; }
 		key_value_pair operator*() const noexcept { return key_value_pair( _pair[0].get_c_str(), _pair[1] ); }

--- a/include/json5/json5_base.hpp
+++ b/include/json5/json5_base.hpp
@@ -134,6 +134,7 @@ struct error final
 		array_expected,     // expected array [ ... ]
 		wrong_array_size,   // invalid number of array elements
 		invalid_enum,       // invalid enum value or string (conversion failed)
+		could_not_open,     // stream is not open
 	};
 
 	static constexpr const char *type_string[] =
@@ -141,7 +142,7 @@ struct error final
 		"none", "invalid root", "unexpected end", "syntax error", "invalid literal",
 		"invalid escape sequence", "comma expected", "colon expected", "boolean expected",
 		"number expected", "string expected", "object expected", "array expected",
-		"wrong array size", "invalid enum"
+		"wrong array size", "invalid enum", "could not open stream",
 	};
 
 	int type = none;

--- a/include/json5/json5_base.hpp
+++ b/include/json5/json5_base.hpp
@@ -13,7 +13,7 @@
 */
 #define JSON5_CLASS(_Name, ...) \
 	template <> struct json5::detail::class_wrapper<_Name> { \
-		static constexpr char* names = #__VA_ARGS__; \
+		static constexpr const char* names = #__VA_ARGS__; \
 		inline static auto make_named_tuple(_Name &out) noexcept { \
 			return std::tuple( names, std::tie( _JSON5_CONCAT( _JSON5_PREFIX_OUT, ( __VA_ARGS__ ) ) ) ); \
 		} \
@@ -35,16 +35,16 @@
 */
 #define JSON5_CLASS_INHERIT(_Name, _Base, ...) \
 	template <> struct json5::detail::class_wrapper<_Name> { \
-		static constexpr char* names = #__VA_ARGS__; \
+		static constexpr const char* names = #__VA_ARGS__; \
 		inline static auto make_named_tuple(_Name &out) noexcept { \
 			return std::tuple_cat( \
 			                       json5::detail::class_wrapper<_Base>::make_named_tuple(out), \
-			                       std::tuple(#__VA_ARGS__, std::tie( _JSON5_CONCAT(_JSON5_PREFIX_OUT, (__VA_ARGS__)) ))); \
+			                       std::tuple(names, std::tie( _JSON5_CONCAT(_JSON5_PREFIX_OUT, (__VA_ARGS__)) ))); \
 		} \
 		inline static auto make_named_tuple(const _Name &in) noexcept { \
 			return std::tuple_cat( \
 			                       json5::detail::class_wrapper<_Base>::make_named_tuple(in), \
-			                       std::tuple(#__VA_ARGS__, std::tie( _JSON5_CONCAT(_JSON5_PREFIX_IN, (__VA_ARGS__)) ))); \
+			                       std::tuple(names, std::tie( _JSON5_CONCAT(_JSON5_PREFIX_IN, (__VA_ARGS__)) ))); \
 		} \
 	};
 
@@ -60,9 +60,9 @@
 */
 #define JSON5_MEMBERS(...) \
 	inline auto make_named_tuple() noexcept { \
-		return std::tuple(#__VA_ARGS__, std::tie( __VA_ARGS__ )); } \
+		return std::tuple((const char*)#__VA_ARGS__, std::tie( __VA_ARGS__ )); } \
 	inline auto make_named_tuple() const noexcept { \
-		return std::tuple(#__VA_ARGS__, std::tie( __VA_ARGS__ )); }
+		return std::tuple((const char*)#__VA_ARGS__, std::tie( __VA_ARGS__ )); }
 
 /*
 	Generates members serialzation helper inside class with inheritance:
@@ -83,11 +83,11 @@
 	inline auto make_named_tuple() noexcept { \
 		return std::tuple_cat( \
 		                       json5::detail::class_wrapper<_Base>::make_named_tuple(*this), \
-		                       std::tuple(#__VA_ARGS__, std::tie( __VA_ARGS__ ))); } \
+		                       std::tuple((const char*)#__VA_ARGS__, std::tie( __VA_ARGS__ ))); } \
 	inline auto make_named_tuple() const noexcept { \
 		return std::tuple_cat( \
 		                       json5::detail::class_wrapper<_Base>::make_named_tuple(*this), \
-		                       std::tuple(#__VA_ARGS__, std::tie( __VA_ARGS__ ))); } \
+		                       std::tuple((const char*)#__VA_ARGS__, std::tie( __VA_ARGS__ ))); } \
 
 /*
 	Generates enum wrapper:
@@ -101,8 +101,8 @@
 #define JSON5_ENUM(_Name, ...) \
 	template <> struct json5::detail::enum_table<_Name> : std::true_type { \
 		using enum _Name; \
-		static constexpr char* names = #__VA_ARGS__; \
-		static constexpr _Name values[] = { __VA_ARGS__ }; };
+		static constexpr const char* names = #__VA_ARGS__; \
+		static constexpr const _Name values[] = { __VA_ARGS__ }; };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -136,7 +136,7 @@ struct error final
 		invalid_enum,       // invalid enum value or string (conversion failed)
 	};
 
-	static constexpr char *type_string[] =
+	static constexpr const char *type_string[] =
 	{
 		"none", "invalid root", "unexpected end", "syntax error", "invalid literal",
 		"invalid escape sequence", "comma expected", "colon expected", "boolean expected",

--- a/include/json5/json5_base.hpp
+++ b/include/json5/json5_base.hpp
@@ -248,5 +248,5 @@ protected:
 #define _JSON5_CONCAT_15(_Prefix, _Args) _Prefix(_JSON5_FIRST _Args),_JSON5_CONCAT_14(_Prefix,_JSON5_TAIL _Args)
 #define _JSON5_CONCAT_16(_Prefix, _Args) _Prefix(_JSON5_FIRST _Args),_JSON5_CONCAT_15(_Prefix,_JSON5_TAIL _Args)
 
-#define _JSON5_PREFIX_IN(_X) _JSON5_JOIN(in., _X)
-#define _JSON5_PREFIX_OUT(_X) _JSON5_JOIN(out., _X)
+#define _JSON5_PREFIX_IN(_X) in. _X
+#define _JSON5_PREFIX_OUT(_X) out. _X

--- a/include/json5/json5_input.hpp
+++ b/include/json5/json5_input.hpp
@@ -358,9 +358,9 @@ inline error parser::parse_number( double &result )
 			break;
 	}
 
-	auto convResult = std::from_chars( buff, buff + length, result );
-
-	if ( convResult.ec != std::errc() )
+	char *end = nullptr;
+	result = strtod(buff, &end);
+	if (buff == end)
 		return make_error( error::syntax_error );
 
 	return { error::none };

--- a/include/json5/json5_input.hpp
+++ b/include/json5/json5_input.hpp
@@ -520,6 +520,9 @@ inline error from_string( const std::string &str, document &doc )
 inline error from_file( const std::string &fileName, document &doc )
 {
 	std::ifstream ifs( fileName );
+	if (!ifs.is_open())
+		return error{ error::could_not_open, 0, 0 };
+
 	return from_stream( ifs, doc );
 }
 

--- a/include/json5/json5_input.hpp
+++ b/include/json5/json5_input.hpp
@@ -369,7 +369,7 @@ inline error parser::parse_number( double &result )
 //---------------------------------------------------------------------------------------------------------------------
 inline error parser::parse_string( detail::string_offset &result )
 {
-	static constexpr char *hexChars = "0123456789abcdefABCDEF";
+	static const constexpr char *hexChars = "0123456789abcdefABCDEF";
 
 	bool singleQuoted = peek() == '\'';
 	next(); // Consume '\'' or '"'

--- a/include/json5/json5_input.hpp
+++ b/include/json5/json5_input.hpp
@@ -504,7 +504,8 @@ inline error parser::parse_literal( token_type &result )
 //---------------------------------------------------------------------------------------------------------------------
 inline error from_stream( std::istream &is, document &doc )
 {
-	parser r( doc, detail::stl_istream( is ) );
+	auto isWrapper = detail::stl_istream( is );
+	parser r( doc, isWrapper );
 	return r.parse();
 }
 

--- a/include/json5/json5_output.hpp
+++ b/include/json5/json5_output.hpp
@@ -208,6 +208,9 @@ inline std::string to_string( const document &doc, const writer_params &wp )
 inline bool to_file( const std::string &fileName, const document &doc, const writer_params &wp )
 {
 	std::ofstream ofs( fileName );
+	if (!ofs.is_open())
+		return false;
+
 	to_stream( ofs, doc, wp );
 	return true;
 }

--- a/include/json5/json5_reflect.hpp
+++ b/include/json5/json5_reflect.hpp
@@ -45,7 +45,7 @@ class writer final : public builder
 public:
 	writer( document &doc, const writer_params &wp ): builder( doc ), _params( wp ) { }
 
-	const writer_params &params() const noexcept { _params; }
+	const writer_params &params() const noexcept { return _params; }
 
 private:
 	writer_params _params;

--- a/include/json5/json5_reflect.hpp
+++ b/include/json5/json5_reflect.hpp
@@ -3,6 +3,7 @@
 #include "json5_builder.hpp"
 
 #include <array>
+#include <fstream>
 #include <map>
 #include <unordered_map>
 
@@ -35,6 +36,9 @@ template <typename T> error from_file( const std::string &fileName, T &out );
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 namespace detail {
+
+// Pre-declare so compiler knows it exists before it is attempted to be used
+template <typename T> error read(const json5::value& in, T& out);
 
 class writer final : public builder
 {

--- a/include/json5/json5_reflect.hpp
+++ b/include/json5/json5_reflect.hpp
@@ -395,7 +395,8 @@ inline error read( const json5::value &in, T &out )
 	if ( !in.is_object() )
 		return { error::object_expected };
 
-	return read_named_tuple( json5::object_view( in ), class_wrapper<T>::make_named_tuple( out ) );
+	auto tuple = class_wrapper<T>::make_named_tuple( out );
+	return read_named_tuple( json5::object_view( in ), tuple );
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I recently used this in a project compiled with LLVM and several corrections/fixes/modifications were needed to pass the compiler.  I've assembled them into small commits to make it easier (so review by commit).

The last commit is actually a pretty serious issue if a non-existant file is path is passed into the parser, it will just enter an infinite loop and never exit because it never checked whether the stream was actually open.